### PR TITLE
convert event api to using hashes instead of hashrefs

### DIFF
--- a/docs/asgi_perl_mapping.mkdn
+++ b/docs/asgi_perl_mapping.mkdn
@@ -196,17 +196,17 @@ sub app {
         my $event = shift;
         
         # Send response headers
-        return $send_cb->({
+        return $send_cb->(
             type    => "http.response.start",
             status  => 200,
             headers => [['content-type', 'text/plain']]
-        });
+        );
     })->then(sub {
         # Send response body
-        return $send_cb->({
+        return $send_cb->(
             type => "http.response.body",
             body => "Hello, world!"
-        });
+        );
     });
 }
 ```
@@ -228,16 +228,16 @@ async sub app {
 
     my $event = await $receive_cb->();
 
-    await $send_cb->({
+    await $send_cb->(
         type    => "http.response.start",
         status  => 200,
         headers => [['content-type', 'text/plain']]
-    });
+    );
 
-    await $send_cb->({
+    await $send_cb->(
         type => "http.response.body",
         body => "Hello, world!"
-    });
+    );
 }
 ```
 ---
@@ -275,15 +275,15 @@ Responses follow the ASGI structure:
 
 Perl equivalent:
 ```perl
-$send_cb->({
+$send_cb->(
     type    => "http.response.start",
     status  => 200,
     headers => [['content-type', 'text/plain']]
-})->then(sub {
-    return $send_cb->({
+)->then(sub {
+    return $send_cb->(
         type => "http.response.body",
         body => "Hello, world!"
-    });
+    );
 });
 ```
 This follows the **IO::Async::Future** pattern for non-blocking execution.
@@ -337,16 +337,16 @@ sub websocket_app {
     my ($scope, $receive_cb, $send_cb) = @_;
     
     # Accept WebSocket connection
-    $send_cb->({ type => "websocket.accept" })->then(sub {
+    $send_cb->( type => "websocket.accept" )->then(sub {
         return $receive_cb->();
     })->then(sub {
         my $event = shift;
         
         # Echo the received message back
-        return $send_cb->({
+        return $send_cb->(
             type => "websocket.send",
             text => $event->{text}
-        });
+        );
     });
 }
 ```

--- a/docs/improvements_sketch.mkdn
+++ b/docs/improvements_sketch.mkdn
@@ -15,15 +15,15 @@ use warnings;
 sub app {
     my ($scope, $receive, $send) = @_;
     # Simulate sending an HTTP response
-    $send->({
+    $send->(
         type    => 'http.response.start',
         status  => 200,
         headers => [ ['content-type', 'text/plain'] ],
-    });
-    $send->({
+    );
+    $send->(
         type => 'http.response.body',
         body => "Hello, ASGI!",
-    });
+    );
 }
 
 # Base middleware that simply wraps the app call.
@@ -83,10 +83,10 @@ sub mqtt_app {
     die "Unsupported protocol" if $scope->{type} ne 'mqtt';
     my $message = $receive->();
     print "MQTT Message Received: $message\n";
-    $send->({
+    $send->(
         type    => 'mqtt.response',
         payload => "MQTT Ack",
-    });
+    );
 }
 
 # Simulated MQTT scope.
@@ -116,7 +116,7 @@ sub sse_app {
     # Ensure the scope is for an HTTP request.
     if ($scope->{type} eq 'http') {
         # Send initial response headers for SSE:
-        $send->({
+        $send->(
             type    => 'http.response.start',
             status  => 200,
             headers => [
@@ -124,27 +124,27 @@ sub sse_app {
                 ['cache-control',  'no-cache'],
                 ['connection',     'keep-alive'],
             ],
-        });
+        );
 
         # In a real SSE implementation, you would likely have a loop that waits
         # for events. Here, we simulate sending 5 events with a delay.
         for my $i (1 .. 5) {
             # Build the SSE-formatted event string.
             my $event = "data: Event $i at " . localtime() . "\n\n";
-            $send->({
+            $send->(
                 type      => 'http.response.body',
                 body      => $event,
                 more_body => 1,  # Indicates more data will follow.
-            });
+            );
             sleep 1;  # Simulate a delay between events.
         }
 
         # End the SSE stream by indicating no more data.
-        $send->({
+        $send->(
             type      => 'http.response.body',
             body      => "",
             more_body => 0,
-        });
+        );
     }
     else {
         die "Unsupported protocol for SSE";
@@ -171,15 +171,15 @@ my $counter = Metrics::Any->new_counter('handle_request', { description => 'Hand
 sub traced_app {
     my ($scope, $receive, $send) = @_;
     $counter->inc();
-    $send->({
+    $send->(
         type    => 'http.response.start',
         status  => 200,
         headers => [ ['content-type', 'text/plain'] ],
-    });
-    $send->({
+    );
+    $send->(
         type => 'http.response.body',
         body => "Hello, traced ASGI app!",
-    });
+    );
 }
 
 my $dummy_receive = sub { return {} };
@@ -217,15 +217,15 @@ sub app_with_background_task {
     my ($scope, $receive, $send) = @_;
     # Launch a background task (e.g., sending an email)
     threads->create(\&background_task, "send email")->detach();
-    $send->({
+    $send->(
         type    => 'http.response.start',
         status  => 200,
         headers => [ ['content-type', 'text/plain'] ],
-    });
-    $send->({
+    );
+    $send->(
         type => 'http.response.body',
         body => "Background task initiated!",
-    });
+    );
 }
 
 my $dummy_receive = sub { return {} };

--- a/lib/PASGI/Server.pm
+++ b/lib/PASGI/Server.pm
@@ -46,17 +46,17 @@ sub start {
                         my $receive = sub { return Future->done };
                         # $send callback writes response events back to the client.
                         my $send = sub {
-                            my ($event) = @_;
-                            if ($event->{type} eq 'http.response.start') {
-                                my $status = $event->{status} // 200;
+                            my (%event) = @_;
+                            if ($event{type} eq 'http.response.start') {
+                                my $status = $event{status} // 200;
                                 $stream->write("HTTP/1.1 $status OK\r\n");
-                                for my $header (@{ $event->{headers} // [] }) {
+                                for my $header (@{ $event{headers} // [] }) {
                                     $stream->write("$header->[0]: $header->[1]\r\n");
                                 }
                                 $stream->write("\r\n");
                             }
-                            elsif ($event->{type} eq 'http.response.body') {
-                                $stream->write($event->{body});
+                            elsif ($event{type} eq 'http.response.body') {
+                                $stream->write($event{body});
                             }
                             return Future->done;
                         };

--- a/t/server.t
+++ b/t/server.t
@@ -11,15 +11,15 @@ if ($pid == 0) {
     my $server = PASGI::Server->new(
         app => sub {
             my ($scope, $receive, $send) = @_;
-            return $send->({
+            return $send->(
                 type    => 'http.response.start',
                 status  => 200,
                 headers => [ ['content-type', 'text/plain'] ],
-            })->then(sub {
-                return $send->({
+            )->then(sub {
+                return $send->(
                     type => 'http.response.body',
                     body => "Hello, World!",
-                });
+                );
             });
         },
         host => '127.0.0.1',


### PR DESCRIPTION
As discussed on IRC, the first choice of hashref was mainly done to mirror the python api, however in Perl it is not a requirement, so we can make things nicer. :)